### PR TITLE
Use post mortem on exception

### DIFF
--- a/pytest_pudb.py
+++ b/pytest_pudb.py
@@ -76,7 +76,7 @@ class PuDBInvoke(object):
             sys.stderr.write("INTERNALERROR> %s\n" %line)
             sys.stderr.flush()
         tb = _postmortem_traceback(excinfo)
-        post_mortem(tb)
+        post_mortem(tb, excinfo)
 
 
 def _enter_pudb(node, excinfo, rep):
@@ -89,7 +89,7 @@ def _enter_pudb(node, excinfo, rep):
     rep.toterminal(tw)
     tw.sep(">", "entering PuDB")
     tb = _postmortem_traceback(excinfo)
-    post_mortem(tb)
+    post_mortem(tb, excinfo)
     rep._pdbshown = True
     return rep
 
@@ -104,12 +104,12 @@ def _postmortem_traceback(excinfo):
         return excinfo._excinfo[2]
 
 
-def post_mortem(tb):
+def post_mortem(tb, excinfo):
     dbg = Debugger()
     stack, i = dbg.get_stack(None, tb)
     dbg.reset()
     i = _find_last_non_hidden_frame(stack)
-    dbg.interaction(stack[i][0])
+    dbg.interaction(stack[i][0], excinfo._excinfo)
 
 
 def _find_last_non_hidden_frame(stack):

--- a/tests.py
+++ b/tests.py
@@ -9,5 +9,5 @@ def test_set_trace_integration():
     assert 1 == 2
 
 
-def test_pudb_inteagration():
+def test_pudb_integration():
     assert 1 == 2


### PR DESCRIPTION
This ensures that pudb opens with the 'unhandled exception' message
visible so users know that an exception has occurred. It also enables
users to inspect the exception value.

Before:

![screen shot 2017-02-23 at 15 05 55](https://cloud.githubusercontent.com/assets/70800/23264826/a3b0f47c-f9da-11e6-894d-73abdbc24ecd.png)

After:

![screen shot 2017-02-23 at 15 05 24](https://cloud.githubusercontent.com/assets/70800/23264843/ae9bfe54-f9da-11e6-80a4-e3539e4636ed.png)