### PR TITLE
[fix] if $HOME wasn't set in [setenv] pudb config was never loaded

### DIFF
--- a/pytest_pudb.py
+++ b/pytest_pudb.py
@@ -1,6 +1,17 @@
 """ interactive debugging with PuDB, the Python Debugger. """
 from __future__ import absolute_import
+
+import os
+
+_home_in_env = "HOME" in os.environ
+if not _home_in_env:
+    os.environ["HOME"] = os.path.expanduser("~")
+
 import pudb
+
+if not _home_in_env:
+    del os.environ["HOME"]
+
 import sys
 import warnings
 


### PR DESCRIPTION
Hello,

This PR fix a very common and hard to debug situation where when using pudb in pytest using this extension, the user's pudb configuration was never loaded and it was really hard to figure out why.

Turns out: [pudb needs $HOME to be set to be able to find it's configuration](https://github.com/inducer/pudb/blob/b52cc6b55d313c2899582e5cc378154d23be3834/pudb/settings.py#L35) and turns out if you use pytest using tox (which you probably should?), [tox won't pass down the $HOME variable by default](https://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables) and you get no warning whatsoever about that.

A temporary solution is to do: 

```ini
[testenv]
setenv =
  HOME={homedir}
```

In your tox config (or all your tox config if you have zillion of projects like I do.)

Or to apply this merge request (which might not be the prettiest tbh).

Or to fix that [at the pudb level?](https://github.com/inducer/pudb/pull/453)

I'm not sure where it's the best to fix that but having to set your pudb config each time (like dozen of times per day) ended up being a bit annoying.

Anyway thanks a lot for this extension :heart: 

Kind regards,