### PR TITLE
Fix `pytest.hookspec.pytest_enter_pdb` expects a `pdb` (keyword) argument

### DIFF
--- a/pytest_pudb.py
+++ b/pytest_pudb.py
@@ -52,7 +52,7 @@ class PuDBWrapper(object):
             tw = self.pluginmanager.getplugin("terminalreporter")._tw
             tw.line()
             tw.sep(">", "entering PuDB (IO-capturing turned off)")
-            self.pluginmanager.hook.pytest_enter_pdb(config=self.config)
+            self.pluginmanager.hook.pytest_enter_pdb(config=self.config, pdb=self._pudb_get_debugger)
 
     def _get_debugger(self, **kwargs):
         self.disable_io_capture()


### PR DESCRIPTION
Pass down the current `pudb` instance, received via `self._pudb_get_debugger`

Fixes:

> ```
> ===================================== warnings summary ======================================
> .../tests/test_sanity.py::test_sanity
>   .../.venv/lib/python3.9/site-packages/pytest_pudb.py:55: UserWarning:
>
>   Argument(s) ('pdb',) which are declared in the hookspec can not be found in this hook call
>
> -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
> ```

Source: https://docs.pytest.org/en/latest/reference/reference.html#pytest.hookspec.pytest_enter_pdb

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>