### PR TITLE
Tox/Travis: Expand Python versions tested

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,17 @@ matrix:
     - python: 3.7
       dist: xenial
       env: TOXENV=py37
+    - python: 3.8
+      dist: xenial
+      env: TOXENV=py38
+    - python: 3.9
+      dist: xenial
+      env: TOXENV=py39
+    - python: 3.10
+      dist: bionic
+      env: TOXENV=py310
+    - python: 3.11
+      dist: bionic
+      env: TOXENV=py311
     - python: 3.6
       env: TOXENV=flake8

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,py37,flake8
+envlist = py26,py27,py34,py35,py36,py37,py38,py39,py310,py311,flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
It is somewhat hard to nowadays "officially use <= 3.7 Pythons" https://devguide.python.org/versions/

Allow testing for more up-to-date versions.

Signed-off-by: Stavros Ntentos <133706+stdedos@users.noreply.github.com>