### PR TITLE
Fix pytest 8.4 incompatibility

### DIFF
--- a/pytest_pudb.py
+++ b/pytest_pudb.py
@@ -18,7 +18,7 @@ def pytest_configure(config):
         config.pluginmanager.register(pudb_wrapper, 'pudb_wrapper')
 
     pudb_wrapper.mount()
-    config._cleanup.append(pudb_wrapper.unmount)
+    config.add_cleanup(pudb_wrapper.unmount)
 
 
 class PuDBWrapper(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length=120
+exclude = venv,.tox
 
 [bdist_wheel]
 universal = 1

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,11 @@ setup(
     author_email='wronglink@gmail.com',
     url='https://github.com/wronglink/pytest-pudb',
     long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
-    version='0.7.0',
+    version='0.8.0',
     py_modules=['pytest_pudb'],
     entry_points={'pytest11': ['pudb = pytest_pudb']},
     install_requires=[
-        'pytest>=2.0',
+        'pytest>=3.0',
         'pudb',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,31 @@
 from setuptools import setup
 
 setup(
-    name='pytest-pudb',
-    license='MIT',
-    description='Pytest PuDB debugger integration',
-    author='Michael Elovskikh',
-    author_email='wronglink@gmail.com',
-    url='https://github.com/wronglink/pytest-pudb',
-    long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
-    version='0.8.0',
-    py_modules=['pytest_pudb'],
-    entry_points={'pytest11': ['pudb = pytest_pudb']},
+    name="pytest-pudb",
+    license="MIT",
+    description="Pytest PuDB debugger integration",
+    author="Michael Elovskikh",
+    author_email="wronglink@gmail.com",
+    url="https://github.com/wronglink/pytest-pudb",
+    long_description=open("README.rst").read() + "\n\n" + open("HISTORY.rst").read(),
+    version="0.8.0",
+    py_modules=["pytest_pudb"],
+    entry_points={"pytest11": ["pudb = pytest_pudb"]},
     install_requires=[
-        'pytest>=3.0',
-        'pudb',
+        "pytest>=7.0",
+        "pudb",
     ],
     extras_require={
-        'dev': [
-            'pexpect',
-            'tox',
-            'flake8',
+        "dev": [
+            "pexpect",
+            "tox",
+            "flake8",
         ]
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Topic :: Software Development :: Testing',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-    ]
+        "Development Status :: 3 - Alpha",
+        "Topic :: Software Development :: Testing",
+        "Intended Audience :: Developers",
+        "Operating System :: OS Independent",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,31 @@
 from setuptools import setup
 
 setup(
-    name="pytest-pudb",
-    license="MIT",
-    description="Pytest PuDB debugger integration",
-    author="Michael Elovskikh",
-    author_email="wronglink@gmail.com",
-    url="https://github.com/wronglink/pytest-pudb",
-    long_description=open("README.rst").read() + "\n\n" + open("HISTORY.rst").read(),
-    version="0.8.0",
-    py_modules=["pytest_pudb"],
-    entry_points={"pytest11": ["pudb = pytest_pudb"]},
+    name='pytest-pudb',
+    license='MIT',
+    description='Pytest PuDB debugger integration',
+    author='Michael Elovskikh',
+    author_email='wronglink@gmail.com',
+    url='https://github.com/wronglink/pytest-pudb',
+    long_description=open('README.rst').read() + '\n\n' + open('HISTORY.rst').read(),
+    version='0.8.0',
+    py_modules=['pytest_pudb'],
+    entry_points={'pytest11': ['pudb = pytest_pudb']},
     install_requires=[
-        "pytest>=7.0",
-        "pudb",
+        'pytest>=7.0',
+        'pudb',
     ],
     extras_require={
-        "dev": [
-            "pexpect",
-            "tox",
-            "flake8",
+        'dev': [
+            'pexpect',
+            'tox',
+            'flake8',
         ]
     },
     classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Topic :: Software Development :: Testing",
-        "Intended Audience :: Developers",
-        "Operating System :: OS Independent",
-    ],
+        'Development Status :: 3 - Alpha',
+        'Topic :: Software Development :: Testing',
+        'Intended Audience :: Developers',
+        'Operating System :: OS Independent',
+    ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,py37,flake8
+envlist = py26,py27,py34,py35,py36,py37,py313,flake8
 
 [testenv]
 commands =


### PR DESCRIPTION
When this package was written, it was targetting version pytest 2.0, which had no public cleanup interface, and it called the protected `config._cleanup`. In version 2.7 the public [`add_cleanup`](https://github.com/pytest-dev/pytest/commit/715a235b45debf5e71e1409a826d91833014f4b5) flag was added ([MR](https://github.com/pytest-dev/pytest/pull/871)).

Then, in version 8.4, the protected [variable was renamed](https://github.com/pytest-dev/pytest/pull/12982/files#diff-df52f8f6a3544754cc8ebdf903594738e68a18dc9ac3c959f646cf4705a9afedR1080), and this package broke.

My MR fixes this bug. I reused the existing tests to make sure it works, and ran them using python 3.13 and pytest 8.4. I don't have any older python versions lying around to test it with, but given the scope of the change it's unlikely to cause regressions.

I bumped the required version of pytest to 7.0, simply because with python 3.13 I wasn't able to get it to work on older versions and I decided the subset of people using this plugin and pytest <7 would be small.

Fixes #28 